### PR TITLE
Add vision prompt documentation

### DIFF
--- a/pallet-tracker/README.md
+++ b/pallet-tracker/README.md
@@ -33,3 +33,10 @@ python update_inventory.py
 ```
 
 Each location cell updated by the script receives the note `Made by AI`.
+
+## Cloud Vision Prompt
+
+The prompt used when processing images with GPT-4 Vision is stored in
+`cloud_vision_prompt.txt`. It explains how to interpret the spreadsheet,
+handle handwritten text, validate product codes using the
+`validateProductCodeTool`, and return the extracted data as a JSON array.

--- a/pallet-tracker/cloud_vision_prompt.txt
+++ b/pallet-tracker/cloud_vision_prompt.txt
@@ -1,0 +1,17 @@
+You are an expert data extraction specialist.
+
+You will receive an image of a spreadsheet detailing product inventory changes or current stock. This spreadsheet may contain handwritten text. Please do your best to interpret any handwriting, paying close attention to common characters and numbers within the context of product names, locations, and quantities.
+
+Your primary task is:
+1. Extract the product name, its **current or new inventory location**, and the **final quantity** for each product.
+2. For **each** product name you extract, you **MUST** use the 'validateProductCodeTool' to check its validity and get any suggestions for correction.
+3. Include the 'isValid' status and any 'suggestion' from the tool's output directly in the product information.
+
+Key details to consider:
+- **Location Format:** Inventory locations often follow a pattern like '12C2' or '9A1' (1 or 2 digits, a letter, then another digit). Pay close attention to accurately extracting this, even from handwritten input.
+- **Data Grouping:** Sometimes, information for a single product might appear split across what looks like multiple rows or tables in the image. If context suggests they belong to the same product entry (e.g., describing a move or update for one item, like an old location and a new location on separate lines), consolidate this information into a single product record.
+- **Interpretation of Movements/Updates:** If the spreadsheet indicates a product movement (e.g., "Product X from location A to location B, new quantity Z" or similar phrasing, potentially across multiple lines), extract the product name (X), the **destination location** (B) as 'location', and the **final quantity** (Z) as 'quantity'. The 'location' field in the output should always represent the product's most current or target location, and 'quantity' its final count there.
+
+Image: {{media url=photoDataUri}}
+
+Return the extracted data as a JSON array of objects, where each object represents a product and contains the fields 'name', 'location', 'quantity', 'isValid', and 'suggestion'. The 'isValid' and 'suggestion' fields MUST come from the output of the 'validateProductCodeTool'.


### PR DESCRIPTION
## Summary
- add `cloud_vision_prompt.txt` with detailed instructions for GPT‑4 Vision
- document the prompt location in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_684b1288ad6883339d53f7824d828afc